### PR TITLE
Fix tileset

### DIFF
--- a/tilesets/dat/tiles/n-4-16.txt
+++ b/tilesets/dat/tiles/n-4-16.txt
@@ -2160,7 +2160,6 @@ $ = (71, 108, 108)
   $$$$$JJOOOOO$$$$
   $$$$$$MJJOOM$$$$
   $$$$$$$MMJJ$$$$$
-
 }
 # tile 1104 (remembered as object pile)
 {


### PR DESCRIPTION
When building the tileset, the follow error occurs:
line 2164: Error: Image width is not consistent

It seems like the empty line messes with the dimensions.