### PR TITLE
make perma-invis harder to acquire

### DIFF
--- a/libnethack/src/eat.c
+++ b/libnethack/src/eat.c
@@ -610,7 +610,8 @@ cpostfx(struct monst *mon, int pm)
     case PM_STALKER:
         if (invisible(mon))
             set_property(mon, SEE_INVIS, 0, FALSE);
-        set_property(mon, INVIS, invisible(mon) ? 0 : rn1(100, 50), FALSE);
+        set_property(mon, INVIS, invisible(mon) ? rn1(500, 1000) :
+                     rn1(100, 50), FALSE);
         /* fall into next case */
     case PM_GIANT_BAT:
         if (!resists_stun(mon))

--- a/libnethack/src/potion.c
+++ b/libnethack/src/potion.c
@@ -680,7 +680,7 @@ peffects(struct monst *mon, struct obj *otmp, int *nothing, int *unkn)
             *nothing = 1;
         int duration = rn1(15, 31);
         if (otmp->blessed)
-            duration = 0; /* permanent */
+            duration = rn1(2222, 1111); /* permanent-ish */
 
         enum youprop prop = INVIS;
         if (otmp->cursed)

--- a/libnethack/src/zap.c
+++ b/libnethack/src/zap.c
@@ -343,12 +343,12 @@ bhitm(struct monst *magr, struct monst *mdef, struct obj *otmp, int range)
                                         FALSE : !!teleport_control(mdef)));
         break;
     case WAN_MAKE_INVISIBLE:
-        if (wandlevel >= P_SKILLED && invisible(mdef))
+        if (wandlevel == P_MASTER && invisible(mdef))
             known = set_property(mdef, INVIS, -2, FALSE);
-        else if (wandlevel == P_UNSKILLED)
+        else if (wandlevel <= P_BASIC)
             known = inc_timeout(mdef, INVIS, rnd(50), FALSE);
         else
-            known = set_property(mdef, INVIS, 0, FALSE);
+            known = inc_timeout(mdef, INVIS, rn1(100, 50), FALSE);
         break;
     case WAN_NOTHING:
     case WAN_LOCKING:


### PR DESCRIPTION
wands, potions, rings, cloaks, spellbooks, stalkers, and an
artifact are all capable of granting invisibility. rather than
trim many of them from the game, make them more relevant by
making perma-invis only available via the following:
ring of invis (uses a slot)
cloak of invis (uses a slot)
potion of wonder (rare)
object properties (uses a slot)
Orb of Detection (quite rare)
blessed, expert use of invis wand

stalkers, wands, and invis-pot now only offer temporary invis.
blessed invis-pot is semi-permanent. (can last up to 3333 turns)

side benefit: prevent a ton of mummy wrapping tedium