### PR TITLE
Fix zombie status line

### DIFF
--- a/libnethack/src/botl.c
+++ b/libnethack/src/botl.c
@@ -291,8 +291,10 @@ make_player_info(struct nh_player_info *pi)
     if (petrifying(&youmonst))     /* 11 */
         strncpy(pi->statusitems[pi->nr_items++], "Petrify", ITEMLEN);
     if (zombie_timer) {
-        if (zombie_timer > 40)
+        if (zombie_timer > TERMINAL_ZOMBIE)
             strncpy(pi->statusitems[pi->nr_items++], "Zombie", ITEMLEN);
+        else if (zombie_timer < TERMINAL_ZOMBIE / 2)
+            strncpy(pi->statusitems[pi->nr_items++], "Zombie!!!", ITEMLEN);
         else
             strncpy(pi->statusitems[pi->nr_items++], "Zombie!", ITEMLEN);
     }

--- a/nethack/src/status.c
+++ b/nethack/src/status.c
@@ -205,7 +205,8 @@ static const struct {
       { "Breath", CLR_BRIGHT_MAGENTA, CLR_BRIGHT_MAGENTA },
       { "Slime", CLR_BRIGHT_MAGENTA, CLR_BRIGHT_MAGENTA },
       { "Petrify", CLR_BRIGHT_MAGENTA, CLR_BRIGHT_MAGENTA },
-      { "Zombie!", CLR_BRIGHT_MAGENTA, CLR_BRIGHT_MAGENTA },
+      { "Zombie!", CLR_MAGENTA, CLR_MAGENTA },
+      { "Zombie!!!", CLR_BRIGHT_MAGENTA, CLR_BRIGHT_MAGENTA },
       { NULL, 0 }
 };
 


### PR DESCRIPTION
The zombie status line was using the hardcoded value of 40 instead of
the global TERMINAL_ZOMBIE.  Since the critical level for
zombification was raised to 50, it no longer matched.

Also added one more step in the status indicator for Zombie!!! just to
make it even more obvious when you are about to die.